### PR TITLE
fix: Apollo Client fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "@apollo/client": "^3.3.11",
     "@ethersproject/address": "^5.0.10",
     "bignumber.js": "^9.0.1",
-    "graphql-tag": "^2.11.0",
-    "node-fetch": "^2.6.1"
+    "cross-fetch": "^3.0.6",
+    "graphql-tag": "^2.11.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
@@ -23,7 +23,6 @@
     "@graphql-codegen/cli": "1.15.4",
     "@graphql-codegen/typescript": "1.15.4",
     "@graphql-codegen/typescript-operations": "^1.15.4",
-    "@types/node-fetch": "^2.5.8",
     "@typescript-eslint/eslint-plugin": "^4.15.1",
     "@typescript-eslint/parser": "^4.15.1",
     "@vercel/node": "^1.9.0",

--- a/utils/apollo/client.ts
+++ b/utils/apollo/client.ts
@@ -1,5 +1,5 @@
 import { ApolloClient, HttpLink, InMemoryCache } from "@apollo/client/core";
-import fetch from "node-fetch";
+import fetch from "cross-fetch";
 
 export const client = new ApolloClient({
   link: new HttpLink({

--- a/utils/blocks/client.ts
+++ b/utils/blocks/client.ts
@@ -1,5 +1,5 @@
 import { ApolloClient, HttpLink, InMemoryCache } from "@apollo/client/core";
-import fetch from "node-fetch";
+import fetch from "cross-fetch";
 
 export const blockClient = new ApolloClient({
   link: new HttpLink({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1143,14 +1143,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
-"@types/node-fetch@^2.5.8":
-  version "2.5.8"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.8.tgz#e199c835d234c7eb0846f6618012e558544ee2fb"
-  integrity sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==
-  dependencies:
-    "@types/node" "*"
-    form-data "^3.0.0"
-
 "@types/node@*":
   version "14.14.28"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.28.tgz#cade4b64f8438f588951a6b35843ce536853f25b"


### PR DESCRIPTION
Fix `Type 'typeof fetch' is not assignable to type '(input: RequestInfo, init?: RequestInit | undefined) => Promise<Response>'.`.